### PR TITLE
feat: added google analytics 4 support

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -19,7 +19,10 @@ export default {
   css: ['~/assets/css/fonts.css', '~/assets/css/main.css'],
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
-  plugins: [],
+  plugins: [
+    // Source: ./plugins/vue-gtag.js
+    '@/plugins/vue-gtag',
+  ],
 
   // Auto import components (https://go.nuxtjs.dev/config-components)
   components: true,

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "core-js": "^3.6.5",
     "lodash": "^4.17.20",
     "nuxt": "^2.14.6",
+    "vue-gtag": "1",
     "vue-marquee-text-component": "^1.2.0",
     "vue-pdf": "^4.3.0",
     "vue-scrollto": "^2.20.0"

--- a/plugins/vue-gtag.js
+++ b/plugins/vue-gtag.js
@@ -1,0 +1,18 @@
+import Vue from 'vue'
+import VueGtag from 'vue-gtag'
+
+// Docs: https://matteo-gabriele.gitbook.io/vue-gtag/
+export default ({ app }) => {
+  Vue.use(
+    VueGtag,
+    {
+      config: {
+        id: 'G-HP8ZXWVLJG',
+        params: {
+          anonymize_ip: true,
+        },
+      },
+    },
+    app.router
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10308,6 +10308,11 @@ vue-eslint-parser@~7.1.0:
     esquery "^1.0.1"
     lodash "^4.17.15"
 
+vue-gtag@1:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/vue-gtag/-/vue-gtag-1.16.1.tgz#edb2f20ab4f6c4d4d372dfecf8c1fcc8ab890181"
+  integrity sha512-5vs0pSGxdqrfXqN1Qwt0ZFXG0iTYjRMu/saddc7QIC5yp+DKgjWQRpGYVa7Pq+KbThxwzzMfo0sGi7ISa6NowA==
+
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz#532955cc1eb208a3d990b3a9f9a70574657e08f2"


### PR DESCRIPTION
## Description

This PR adds support for google analytics 4. I've done this by building a custom nuxt plugin based on [vue-gtag documentation](https://matteo-gabriele.gitbook.io/vue-gtag/).

- This PR uses v1 of vue-gtag instead of v2 since this website is on nuxt v2 (not v3).
- This PR didn't use [`nuxt/google-analytics`](https://google-analytics.nuxtjs.org/) because it doesn't (yet) support google analytics 4.

## Commit Message

```text
feat: added google analytics 4 support
```